### PR TITLE
Get camera switch to work on iOS

### DIFF
--- a/src/assets/videoInterface.js
+++ b/src/assets/videoInterface.js
@@ -18,7 +18,7 @@ let cameraFacingMode = 'user'
 
 let defaultsOpts = { audio: false, video: true }
 let shouldFaceUser = true;
-let stream = null;
+let currentLocalVideoTrack = null;
 
 const isMobile = (() => {
     if (typeof navigator === 'undefined' || typeof navigator.userAgent !== 'string') {
@@ -31,42 +31,34 @@ import VideoRecorder from "@/assets/VideoRecorder";
 
 export default {
 
-    captureBack() {
+    captureBack(localVideoTrack) {
         var container = document.getElementById('localTrack')
         var video =  container.firstChild
         console.log(video)
         defaultsOpts.video = { facingMode: { exact: "environment" }  }
         console.log(defaultsOpts)
 
-        navigator.mediaDevices.getUserMedia(defaultsOpts)
-            .then(function(_stream) {
-                stream  = _stream;
-                console.log(stream)
-                video.srcObject = stream;
-                video.play();
-            })
-            .catch(function(err) {
-                console.log(err)
-            });
+        localVideoTrack.restart(defaultsOpts.video).then(() => {
+            if (!currentLocalVideoTrack) {
+                currentLocalVideoTrack = localVideoTrack;
+                localVideoTrack.attach(video);
+            }
+        });
     },
 
-    captureFront() {
+    captureFront(localVideoTrack) {
         var container = document.getElementById('localTrack')
         var video =  container.firstChild
         console.log(video)
         defaultsOpts.video = { facingMode: { exact: "user" } }
         console.log(defaultsOpts)
 
-        navigator.mediaDevices.getUserMedia(defaultsOpts)
-            .then(function(_stream) {
-                stream  = _stream;
-                console.log(stream)
-                video.srcObject = stream;
-                video.play();
-            })
-            .catch(function(err) {
-                console.log(err)
-            });
+        localVideoTrack.restart(defaultsOpts.video).then(() => {
+            if (!currentLocalVideoTrack) {
+                currentLocalVideoTrack = localVideoTrack;
+                localVideoTrack.attach(video);
+            }
+        });
     },
 
     startRecording: function (element,localVideoElement,remoteVideoElement, localVideo, remoteVideo){

--- a/src/components/Video.vue
+++ b/src/components/Video.vue
@@ -139,18 +139,9 @@ export default {
 
        var localParticipant = this.activeRoom.localParticipant
        const tracks = Array.from(localParticipant.videoTracks.values()).map(publication => publication.track);
-       this.stream = tracks
-       if( this.stream == null ) return
-       // we need to flip, stop everything
-       this.stream.forEach(t => {
-         t.stop();
-       });
        // toggle / flip
        this.shouldFaceUser = !this.shouldFaceUser;
-       videoInterface.captureBack()
-       const cameraTrack = tracks.find(track => track.kind === 'video');
-       // Switch to the back facing camera.
-       cameraTrack.restart({ facingMode: 'environment' });
+       videoInterface.captureBack(tracks.find(track => track.kind === 'video'))
     },
 
 
@@ -163,19 +154,9 @@ export default {
       var localParticipant = this.activeRoom.localParticipant
       const tracks = Array.from(localParticipant.videoTracks.values()).map(publication => publication.track);
       this.stream = tracks
-      if( this.stream == null ) return
-      // we need to flip, stop everything
-      this.stream.forEach(t => {
-        t.stop();
-      });
-
-      const cameraTrack = tracks.find(track => track.kind === 'video');
-      // Switch to the back facing camera.
-      cameraTrack.restart({ facingMode: 'user' });
-
       // toggle / flip
       this.shouldFaceUser = !this.shouldFaceUser;
-      videoInterface.captureFront()
+      videoInterface.captureFront(tracks.find(track => track.kind === 'video'))
     },
 
     muteAndUnmuteAudio:function (status){


### PR DESCRIPTION
@dinuone ,

The reason why your local preview was freezing is because you have created two tracks when you flip the camera, one for preview and one for publishing to the room. On mobile devices, only one track can access the camera at a time. So, with the changes in this PR, I got the camera flip to work.